### PR TITLE
Aarch64 Appimage Support and cleanup 

### DIFF
--- a/scripts/AppImage/makeAppImage.sh
+++ b/scripts/AppImage/makeAppImage.sh
@@ -1,35 +1,48 @@
-mkdir build
+mkdir -p build
 
-# Download LinuxDeploy.
-if [ ! -f build/linuxdeploy-x86_64.AppImage ]; then
-	wget -O build/linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/2.0.0-alpha-1-20241106/linuxdeploy-x86_64.AppImage
-	if [ $? -ne 0 ]; then
-		curl -L -o build/linuxdeploy-x86_64.AppImage https://github.com/linuxdeploy/linuxdeploy/releases/download/2.0.0-alpha-1-20241106/linuxdeploy-x86_64.AppImage
-	fi
+# Detect architecture
+ARCH=$(uname -m)
+
+# Set linuxdeploy filename based on architecture
+if [ "$ARCH" = "x86_64" ]; then
+    LINUXDEPLOY_FILENAME=linuxdeploy-x86_64.AppImage
+elif [ "$ARCH" = "aarch64" ]; then
+    LINUXDEPLOY_FILENAME=linuxdeploy-aarch64.AppImage
+else
+    echo "Unsupported architecture: $ARCH"
+    exit 1
+fi
+
+# Download LinuxDeploy if not already downloaded.
+if [ ! -f "build/$LINUXDEPLOY_FILENAME" ]; then
+    wget -O "build/$LINUXDEPLOY_FILENAME" "https://github.com/linuxdeploy/linuxdeploy/releases/download/2.0.0-alpha-1-20241106/$LINUXDEPLOY_FILENAME"
+    if [ $? -ne 0 ]; then
+        curl -L -o "build/$LINUXDEPLOY_FILENAME" "https://github.com/linuxdeploy/linuxdeploy/releases/download/2.0.0-alpha-1-20241106/$LINUXDEPLOY_FILENAME"
+    fi
 fi
 
 # Make LinuxDeploy executable.
-chmod +x build/linuxdeploy-x86_64.AppImage
+chmod +x "build/$LINUXDEPLOY_FILENAME"
 
-# We want...
-# - An optimised Release build.
-# - For the program to not be installed to '/usr/local', so that LinuxDeploy detects it.
-# - Link-time optimisation, for improved optimisation.
-# - To set the CMake policy that normally prevents link-time optimisation.
-# - FreeType font rendering, since using a system library means less bloat in the executable.
-cmake -B build ../../ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON -DCMAKE_POLICY_DEFAULT_CMP0069=NEW -DCLOWNMDEMU_FRONTEND_FREETYPE=ON
+# CMake configuration
+cmake -B build ../../ \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+    -DCMAKE_POLICY_DEFAULT_CMP0069=NEW \
+    -DCLOWNMDEMU_FRONTEND_FREETYPE=ON
 
-# Once again specify the Release build, for generators that required it be done this way.
-# Build in parallel to speed-up compilation greatly.
+# Build the project in parallel
 cmake --build build --config Release --parallel $(nproc)
 
-# Make a temporary directory to install the built files into.
-# Make sure that it is fresh and empty, in case this script was ran before. We don't want old, leftover files.
-rm -r build/AppDir
-mkdir build/AppDir
+# Prepare AppDir
+rm -rf build/AppDir
+mkdir -p build/AppDir
 
-# Install into the temporary directory.
+# Install into AppDir
 DESTDIR=AppDir cmake --build build --target install
 
-# Produce the AppImage, and bundle it with update metadata.
-LINUXDEPLOY_OUTPUT_VERSION=v1.2 LDAI_UPDATE_INFORMATION="gh-releases-zsync|Clownacy|clownmdemu-frontend|latest|ClownMDEmu-*x86_64.AppImage.zsync" build/linuxdeploy-x86_64.AppImage --appdir build/AppDir --output appimage
+# Produce the AppImage with architecture-specific naming
+LINUXDEPLOY_OUTPUT_VERSION=v1.2 \
+LDAI_UPDATE_INFORMATION="gh-releases-zsync|Clownacy|clownmdemu-frontend|latest|ClownMDEmu-*${ARCH}.AppImage.zsync" \
+"build/$LINUXDEPLOY_FILENAME" --appdir build/AppDir --output appimage

--- a/scripts/AppImage/makeAppImage.sh
+++ b/scripts/AppImage/makeAppImage.sh
@@ -15,9 +15,9 @@ fi
 
 # Download LinuxDeploy if not already downloaded.
 if [ ! -f "build/$LINUXDEPLOY_FILENAME" ]; then
-    wget -O "build/$LINUXDEPLOY_FILENAME" "https://github.com/linuxdeploy/linuxdeploy/releases/download/2.0.0-alpha-1-20241106/$LINUXDEPLOY_FILENAME"
+    wget -O "build/$LINUXDEPLOY_FILENAME" "https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/$LINUXDEPLOY_FILENAME"
     if [ $? -ne 0 ]; then
-        curl -L -o "build/$LINUXDEPLOY_FILENAME" "https://github.com/linuxdeploy/linuxdeploy/releases/download/2.0.0-alpha-1-20241106/$LINUXDEPLOY_FILENAME"
+        curl -L -o "build/$LINUXDEPLOY_FILENAME" "https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/$LINUXDEPLOY_FILENAME"
     fi
 fi
 


### PR DESCRIPTION
I had to update the link to an operational one because it was broken, they have removed it
As soon as it is fixed mainline https://github.com/linuxdeploy/linuxdeploy/issues/309
Will be to update the link continuous (Currently) do not generate zsync