### PR TITLE
Change fast forward keybind label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 # CMake build directory
 /build
+# clangd cache directory
+/.cache

--- a/README.md
+++ b/README.md
@@ -40,22 +40,22 @@ The default control scheme is as follows:
 
 ### Controller
 
-| Input | Action       |
-| ----- | ------------ |
-| Up    | Up           |
-| Down  | Down         |
-| Left  | Left         |
-| Right | Right        |
-| X     | A            |
-| A     | B            |
-| B     | C            |
-| LB    | X            |
-| Y     | Y            |
-| RB    | Z            |
-| Start | Start        |
-| Back  | Mode         |
-| LT    | Rewind       |
-| RT    | Fast-forward |
+| Input | Action                     |
+| ----- | -------------------------- |
+| Up    | Up                         |
+| Down  | Down                       |
+| Left  | Left                       |
+| Right | Right                      |
+| X     | A                          |
+| A     | B                          |
+| B     | C                          |
+| LB    | X                          |
+| Y     | Y                          |
+| RB    | Z                          |
+| Start | Start                      |
+| Back  | Mode                       |
+| LT    | Rewind                     |
+| RT    | Fast-forward/frame advance |
 | RSB   | [Toggle menu controls](http://www.dearimgui.org/controls_sheets/imgui%20controls%20v6%20-%20Xbox.png) |
 
 ### Hotkeys

--- a/frontend.cpp
+++ b/frontend.cpp
@@ -613,7 +613,7 @@ private:
 			"Control Pad Mode",
 			"Pause",
 			"Reset",
-			"Fast-Forward",
+			"Fast-Forward/Frame Advance",
 			"Rewind",
 			"Quick Save State",
 			"Quick Load State",


### PR DESCRIPTION
Very small PR, but it took me a while to notice that fast-forwarding when paused advances to the next frame. I changed the keybind's menu label to "Fast-Forward/Frame Advance".