### PR TITLE
Qt frontend: Fix incorrect cropping of the framebuffer during rendering

### DIFF
--- a/qt/fragment.glsl
+++ b/qt/fragment.glsl
@@ -19,57 +19,13 @@ out COMPAT_PRECISION vec4 FragColor;
 #define COMPAT_TEXTURE texture2D
 #endif
 
-uniform COMPAT_PRECISION vec2 OutputSize;
-uniform COMPAT_PRECISION vec2 OutputSizeAspectCorrected;
-uniform COMPAT_PRECISION vec2 TextureSize;
-uniform COMPAT_PRECISION vec2 InputSize;
+varying vec2 TextureCoordinate;
+uniform vec2 InputSize;
+uniform vec2 TextureSize;
 uniform sampler2D Texture0;
 
 void main()
 {
-	// Automatically compute the texture coordinates, using the fragment coordinate as a base.
-	vec2 texture_coordinate = gl_FragCoord.xy;
-
-	// Un-flip the Y axis.
-	texture_coordinate.y = OutputSize.y - texture_coordinate.y;
-
-	// Move from the pixel centre to the top-left coordinate.
-	texture_coordinate -= 0.5;
-
-	// Centre the aspect-ratio-corrected view within the window.
-	// We floor this because do not want it to cause blurry sub-pixel rendering.
-	texture_coordinate -= floor((OutputSize - OutputSizeAspectCorrected) * 0.5);
-
-	// Smooth the edges of the texels by interpolating within the fragment.
-
-	// Obtain upper and lower bounds of the fragment, shrunk into the aspect-ratio-corrected view.
-	vec2 lower_texture_coordinate = (texture_coordinate + 0.0) * InputSize / OutputSizeAspectCorrected;
-	vec2 upper_texture_coordinate = (texture_coordinate + 1.0) * InputSize / OutputSizeAspectCorrected;
-
-	// Ignore texels that are outside the view.
-	if (lower_texture_coordinate.x < 0.0 || upper_texture_coordinate.x > InputSize.x || lower_texture_coordinate.y < 0.0 || upper_texture_coordinate.y > InputSize.y)
-	{
-		FragColor = vec4(0.0, 0.0, 0.0, 1.0);
-	}
-	else
-	{
-		// Compute the interpolation weights.
-		// To do this, we measure the space between the upper and lower coordinate bounds,
-		// and then determine at which point it crosses an integer boundary.
-		// If it does not cross a boundary, then the 'max' function will clamp the output
-		// to a sane value.
-		// Note that this does not work correctly if the space crosses MULTIPLE integer
-		// boundaries, but that would only occur when downscaling without mipmapping.
-		vec2 delta = upper_texture_coordinate - lower_texture_coordinate;
-		vec2 weight = max(delta - fract(upper_texture_coordinate), 0.0) / delta;
-
-		// Obtain the centre of the texel that the upper coordinates lies within.
-		vec2 interpolated_texture_coordinate = upper_texture_coordinate - fract(upper_texture_coordinate) + 0.5;
-
-		// Offset the texel centre by the weight, causing the bilinear filter to interpolate the texel with its predecessor.
-		interpolated_texture_coordinate -= weight;
-
-		// Finally, sample the texture. The bilinear filter will ensure that uneven texels will have a smooth edge.
-		FragColor = COMPAT_TEXTURE(Texture0, interpolated_texture_coordinate / TextureSize);
-	}
+	vec2 texel_coord = floor(TextureCoordinate * InputSize) + 0.5;
+	FragColor = COMPAT_TEXTURE(Texture0, texel_coord / TextureSize);
 }

--- a/qt/vertex.glsl
+++ b/qt/vertex.glsl
@@ -5,9 +5,12 @@ precision mediump float;
 
 attribute vec4 vertex_position;
 
-uniform vec2 texture_coordinate_scale;
+varying vec2 TextureCoordinate;
+uniform vec2 OutputSize;
+uniform vec2 OutputSizeAspectCorrected;
 
 void main()
 {
-	gl_Position = vertex_position;
+	gl_Position = vec4(vertex_position.xy * (OutputSizeAspectCorrected / OutputSize), 0.0, 1.0);
+	TextureCoordinate = vec2(vertex_position.x * 0.5 + 0.5, 0.5 - vertex_position.y * 0.5);
 }


### PR DESCRIPTION
On my system, the Qt frontend currently renders a small rectangle instead of the whole framebuffer. I do not know where the size of the rectangle comes from, but I do know it does not scale with the game or the window; if I resize the window to be smaller than or equal to the size of the rectangle, the game is clearly visible.

I genuinely do not know the root cause of this issue. I also do not know if this issue is present on systems other than mine.

I started by looking over the logic in `Emulator::paintGL` and in `fragment.glsl`. Any changes I made at this point had no effect in solving the problem because it seemed the texture itself did not contain the data I was trying to get on-screen. `vertex.glsl` seemed like the next reasonable thing to mess with because it's the last remaining input to the GPU pipeline. Moving the aspect ratio & scaling logic to the vertex shader seemed to do the trick.

Before fix:
<img src="https://github.com/user-attachments/assets/ebd1e2bc-5171-4487-9d4c-93f1dfb5446a" />
<img width="128" height="118" alt="image" src="https://github.com/user-attachments/assets/1811c60c-38a6-4bce-846e-93a17507f5d0" />

After fix:
<img src="https://github.com/user-attachments/assets/587bdb0f-f464-4a45-b5a2-8579bc9aaa55" />

Minutia:
OS: NixOS 26.05, nvidia-open 580.119.02
WM: Hyprland 0.53.0
Qt 6.10.1
