### PR TITLE
Add VGM logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ add_executable(clownmdemu WIN32
 	"source/text-encoding.cpp"
 	"source/text-encoding.h"
 	"source/version.h"
+	"source/vgm-logger.cpp"
+	"source/vgm-logger.h"
 	"source/windows/about.cpp"
 	"source/windows/about.h"
 	"source/windows/cheats.cpp"

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -30,6 +30,7 @@ qt_add_executable(clownmdemu-frontend-qt
 	../source/emulator-extended.h
 	../source/raii-wrapper.h ../source/sdl-wrapper.h
 	../source/text-encoding.cpp ../source/text-encoding.h
+	../source/vgm-logger.cpp ../source/vgm-logger.h
 )
 
 set_target_properties(clownmdemu-frontend-qt PROPERTIES

--- a/source/emulator-extended.h
+++ b/source/emulator-extended.h
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <fstream>
 #include <type_traits>
+#include <vector>
 
 #include "../common/core/source/clownmdemu.h"
 #include "../common/cheat.h"
@@ -15,6 +16,7 @@
 #include "debug-log.h"
 #include "sdl-wrapper.h"
 #include "text-encoding.h"
+#include "vgm-logger.h"
 
 template<typename Derived, typename Colour>
 class EmulatorExtended : public ClownMDEmuCXX::Emulator<Derived>
@@ -155,6 +157,7 @@ private:
 	std::filesystem::path save_file_directory;
 	std::filesystem::path cartridge_save_file_path;
 	unsigned int speed = 1;
+	VGMLogger vgm_logger;
 
 	////////////////////////
 	// Emulator Callbacks //
@@ -256,6 +259,11 @@ private:
 		std::error_code ec;
 		*size = std::filesystem::file_size(save_file_directory / filename, ec);
 		return !ec;
+	}
+
+	void SoundChipWritten(const ClownMDEmu_SoundChip chip, const cc_u8f address, const cc_u8f data, const cc_u32f cycle)
+	{
+		vgm_logger.LogWrite(chip, address, data, cycle);
 	}
 
 	/////////////////////////
@@ -525,6 +533,7 @@ public:
 
 			cheat_manager.ApplyRAMPatches(this);
 			Emulator::Iterate();
+			vgm_logger.AdvanceFrame();
 
 			// Resample, mix, and output the audio for this frame.
 			audio_output.MixerEnd();
@@ -561,6 +570,25 @@ public:
 	[[nodiscard]] cc_u32f GetAudioTargetFrames() const { return audio_output.GetTargetFrames(); }
 	[[nodiscard]] cc_u32f GetAudioTotalBufferFrames() const { return audio_output.GetTotalBufferFrames(); }
 	[[nodiscard]] cc_u32f GetAudioSampleRate() const { return audio_output.GetSampleRate(); }
+
+	/////////////////
+	// VGM Logging //
+	/////////////////
+
+	void StartVGMLogging()
+	{
+		vgm_logger.Start(this->GetTVStandard() == CLOWNMDEMU_TV_STANDARD_PAL, GetSoftwareName());
+	}
+
+	[[nodiscard]] std::vector<unsigned char> StopVGMLogging()
+	{
+		return vgm_logger.Finish();
+	}
+
+	[[nodiscard]] bool IsVGMLogging() const
+	{
+		return vgm_logger.IsRecording();
+	}
 
 	////////////////////
 	// Colour Palette //

--- a/source/frontend.cpp
+++ b/source/frontend.cpp
@@ -2244,6 +2244,22 @@ void Frontend::Update()
 
 				PopupButton("Disassembler", disassembler_window, nullptr, std::make_pair(380, 410));
 
+				if (!emulator->IsVGMLogging())
+				{
+					if (ImGui::MenuItem("Start VGM Recording", nullptr, false, emulator_on))
+						emulator->StartVGMLogging();
+				}
+				else
+				{
+					if (ImGui::MenuItem("Stop VGM Recording..."))
+					{
+						file_utilities.SaveFile(*window, "Create VGM Recording", "recording.vgm", {}, [vgm_data = emulator->StopVGMLogging()](const FileUtilities::SaveFileInnerCallback &callback)
+						{
+							return callback(std::data(vgm_data), std::size(vgm_data));
+						});
+					}
+				}
+
 				ImGui::Separator();
 
 				PopupButton("Frontend", debug_frontend_window, nullptr, std::make_pair(400, 210));

--- a/source/text-encoding.cpp
+++ b/source/text-encoding.cpp
@@ -854,3 +854,65 @@ std::optional<std::string> UTF32ToUTF8(const cc_u32f utf32_codepoint)
 
 	return utf8;
 }
+
+cc_u32f UTF8ToUTF32(const unsigned char* const in_buffer, cc_u8f* const bytes_read)
+{
+	cc_u32f codepoint, minimum_codepoint;
+	cc_u8f total_bytes;
+
+	if (in_buffer[0] < 0x80)
+	{
+		codepoint = in_buffer[0];
+		minimum_codepoint = 0;
+		total_bytes = 1;
+	}
+	else if ((in_buffer[0] & 0xE0) == 0xC0)
+	{
+		codepoint = in_buffer[0] & 0x1F;
+		minimum_codepoint = 0x80;
+		total_bytes = 2;
+	}
+	else if ((in_buffer[0] & 0xF0) == 0xE0)
+	{
+		codepoint = in_buffer[0] & 0x0F;
+		minimum_codepoint = 0x800;
+		total_bytes = 3;
+	}
+	else if ((in_buffer[0] & 0xF8) == 0xF0)
+	{
+		codepoint = in_buffer[0] & 0x07;
+		minimum_codepoint = 0x10000;
+		total_bytes = 4;
+	}
+	else
+	{
+		/* Invalid leading byte. */
+		if (bytes_read != nullptr)
+			*bytes_read = 1;
+
+		return ' ';
+	}
+
+	for (cc_u8f i = 1; i < total_bytes; ++i)
+	{
+		/* Bail out if the sequence is truncated. */
+		if ((in_buffer[i] & 0xC0) != 0x80)
+		{
+			if (bytes_read != nullptr)
+				*bytes_read = i;
+
+			return ' ';
+		}
+
+		codepoint = codepoint << 6 | (in_buffer[i] & 0x3F);
+	}
+
+	if (bytes_read != nullptr)
+		*bytes_read = total_bytes;
+
+	/* Reject overlong sequences, UTF-16 surrogates, and codepoints beyond Unicode. */
+	if (codepoint < minimum_codepoint || (codepoint >= 0xD800 && codepoint < 0xE000) || codepoint >= 0x110000)
+		return ' ';
+
+	return codepoint;
+}

--- a/source/text-encoding.h
+++ b/source/text-encoding.h
@@ -13,4 +13,8 @@ cc_u16l ShiftJISToUTF32(const unsigned char* const in_buffer, cc_u8f* const byte
 /* Returns number of bytes written (maximum 4). */
 std::optional<std::string> UTF32ToUTF8(const cc_u32f utf32_codepoint);
 
+/* Returns UTF-32 codepoint. */
+/* Reads a maximum of four bytes. */
+cc_u32f UTF8ToUTF32(const unsigned char* const in_buffer, cc_u8f* const bytes_read);
+
 #endif /* TEXT_ENCODING_H */

--- a/source/vgm-logger.cpp
+++ b/source/vgm-logger.cpp
@@ -1,0 +1,185 @@
+#include "vgm-logger.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <utility>
+
+#include "text-encoding.h"
+
+static void WriteU16LE(std::vector<unsigned char> &buffer, const cc_u16f value)
+{
+	buffer.push_back((value >> 0) & 0xFF);
+	buffer.push_back((value >> 8) & 0xFF);
+}
+
+static void WriteU32LE(std::vector<unsigned char> &buffer, const cc_u32f value)
+{
+	buffer.push_back((value >> 0) & 0xFF);
+	buffer.push_back((value >> 8) & 0xFF);
+	buffer.push_back((value >> 16) & 0xFF);
+	buffer.push_back((value >> 24) & 0xFF);
+}
+
+static void WriteU32LE(std::vector<unsigned char> &buffer, const std::size_t offset, const cc_u32f value)
+{
+	buffer[offset + 0] = (value >> 0) & 0xFF;
+	buffer[offset + 1] = (value >> 8) & 0xFF;
+	buffer[offset + 2] = (value >> 16) & 0xFF;
+	buffer[offset + 3] = (value >> 24) & 0xFF;
+}
+
+// Writes 'text' converted from UTF-8 to null-terminated UTF-16LE.
+static void WriteGD3String(std::vector<unsigned char> &buffer, const std::string &text)
+{
+	cc_u8f bytes_read;
+
+	for (std::size_t i = 0; i < std::size(text); i += bytes_read)
+	{
+		cc_u32f codepoint = UTF8ToUTF32(reinterpret_cast<const unsigned char*>(&text[i]), &bytes_read);
+
+		if (codepoint <= 0xFFFF)
+		{
+			WriteU16LE(buffer, codepoint);
+		}
+		else
+		{
+			// Encode as a UTF-16 surrogate pair.
+			codepoint -= 0x10000;
+			WriteU16LE(buffer, 0xD800 + (codepoint >> 10));
+			WriteU16LE(buffer, 0xDC00 + (codepoint & 0x3FF));
+		}
+	}
+
+	WriteU16LE(buffer, 0);
+}
+
+void VGMLogger::WriteWait(Uint64 samples)
+{
+	// The wait command's sample count is only 16-bit, so long waits must be split-up.
+	while (samples != 0)
+	{
+		const cc_u16f chunk = std::min<Uint64>(samples, 0xFFFF);
+
+		commands.push_back(0x61); // Wait.
+		WriteU16LE(commands, chunk);
+
+		samples -= chunk;
+		total_samples += chunk;
+	}
+}
+
+void VGMLogger::Start(const bool pal_mode, std::string software_name)
+{
+	master_clock = pal_mode ? CLOWNMDEMU_MASTER_CLOCK_PAL : CLOWNMDEMU_MASTER_CLOCK_NTSC;
+	cycles_per_frame = pal_mode ? CLOWNMDEMU_DIVIDE_BY_PAL_FRAMERATE(CLOWNMDEMU_MASTER_CLOCK_PAL) : CLOWNMDEMU_DIVIDE_BY_NTSC_FRAMERATE(CLOWNMDEMU_MASTER_CLOCK_NTSC);
+	ym2612_clock = pal_mode ? CLOWNMDEMU_M68K_CLOCK_PAL : CLOWNMDEMU_M68K_CLOCK_NTSC;
+	sn76489_clock = pal_mode ? CLOWNMDEMU_Z80_CLOCK_PAL : CLOWNMDEMU_Z80_CLOCK_NTSC;
+	frame_rate = pal_mode ? 50 : 60;
+	frame_cycle_base = 0;
+	start_sample = 0;
+	total_samples = 0;
+	commands.clear();
+	this->software_name = std::move(software_name);
+
+	recording = true;
+}
+
+void VGMLogger::LogWrite(const ClownMDEmu_SoundChip chip, const cc_u8f address, const cc_u8f data, const cc_u32f cycle)
+{
+	if (!recording)
+		return;
+
+	// Convert the master-clock cycle at which the write occurred to a VGM sample.
+	const Uint64 target_sample = (frame_cycle_base + cycle) * sample_rate / master_clock;
+
+	// Begin the recording at the first write, trimming the leading silence.
+	if (commands.empty())
+		start_sample = target_sample;
+
+	if (target_sample > start_sample + total_samples)
+		WriteWait(target_sample - start_sample - total_samples);
+
+	switch (chip)
+	{
+		case CLOWNMDEMU_SOUND_CHIP_FM_PORT0:
+			commands.push_back(0x52); // YM2612 port 0 write.
+			commands.push_back(address);
+			commands.push_back(data);
+			break;
+
+		case CLOWNMDEMU_SOUND_CHIP_FM_PORT1:
+			commands.push_back(0x53); // YM2612 port 1 write.
+			commands.push_back(address);
+			commands.push_back(data);
+			break;
+
+		case CLOWNMDEMU_SOUND_CHIP_PSG:
+			commands.push_back(0x50); // SN76489 write.
+			commands.push_back(data);
+			break;
+	}
+}
+
+void VGMLogger::AdvanceFrame()
+{
+	if (recording)
+		frame_cycle_base += cycles_per_frame;
+}
+
+std::vector<unsigned char> VGMLogger::Finish()
+{
+	recording = false;
+
+	commands.push_back(0x66); // End of sound data.
+
+	// Produce the GD3 tag.
+	std::vector<unsigned char> gd3;
+	gd3.push_back('G');
+	gd3.push_back('d');
+	gd3.push_back('3');
+	gd3.push_back(' ');
+	WriteU32LE(gd3, 0x100); // Version 1.00.
+
+	const auto gd3_length_offset = std::size(gd3);
+	WriteU32LE(gd3, 0); // Placeholder for the length of the string data.
+
+	const auto gd3_strings_offset = std::size(gd3);
+	WriteGD3String(gd3, "");                          // Track name (English)
+	WriteGD3String(gd3, "");                          // Track name (Japanese)
+	WriteGD3String(gd3, software_name);               // Game name (English)
+	WriteGD3String(gd3, "");                          // Game name (Japanese)
+	WriteGD3String(gd3, "Sega Mega Drive / Genesis"); // System name (English)
+	WriteGD3String(gd3, "");                          // System name (Japanese)
+	WriteGD3String(gd3, "");                          // Track author (English)
+	WriteGD3String(gd3, "");                          // Track author (Japanese)
+	WriteGD3String(gd3, "");                          // Release date
+	WriteGD3String(gd3, "ClownMDEmu");                // VGM creator
+	WriteGD3String(gd3, "");                          // Notes
+	WriteU32LE(gd3, gd3_length_offset, std::size(gd3) - gd3_strings_offset);
+
+	// Lay out the file: the header, then the command stream, then the GD3 tag.
+	constexpr std::size_t header_size = 0x100;
+	const auto gd3_offset = header_size + std::size(commands);
+	const auto total_size = gd3_offset + std::size(gd3);
+
+	std::vector<unsigned char> file_buffer(header_size);
+	file_buffer[0x00] = 'V';
+	file_buffer[0x01] = 'g';
+	file_buffer[0x02] = 'm';
+	file_buffer[0x03] = ' ';
+	WriteU32LE(file_buffer, 0x04, total_size - 0x04);  // End-of-file offset
+	WriteU32LE(file_buffer, 0x08, 0x151);              // Version 1.51
+	WriteU32LE(file_buffer, 0x0C, sn76489_clock);
+	WriteU32LE(file_buffer, 0x14, gd3_offset - 0x14);  // GD3 tag offset
+	WriteU32LE(file_buffer, 0x18, total_samples);
+	WriteU32LE(file_buffer, 0x24, frame_rate);
+	file_buffer[0x28] = 0x09;                          // SN76489 feedback pattern
+	file_buffer[0x2A] = 16;                            // SN76489 shift register width
+	WriteU32LE(file_buffer, 0x2C, ym2612_clock);
+	WriteU32LE(file_buffer, 0x34, header_size - 0x34); // Command stream offset
+
+	file_buffer.insert(file_buffer.end(), commands.begin(), commands.end());
+	file_buffer.insert(file_buffer.end(), gd3.begin(), gd3.end());
+
+	return file_buffer;
+}

--- a/source/vgm-logger.h
+++ b/source/vgm-logger.h
@@ -1,0 +1,40 @@
+#ifndef VGM_LOGGER_H
+#define VGM_LOGGER_H
+
+#include <string>
+#include <vector>
+
+#include <SDL3/SDL.h>
+
+#include "../common/core/source/clownmdemu.h"
+
+class VGMLogger
+{
+private:
+	// All VGM timing is measured in samples at this rate, regardless of chip clocks.
+	static constexpr cc_u32f sample_rate = 44100;
+
+	bool recording = false;
+	cc_u32f master_clock;
+	cc_u32f cycles_per_frame;
+	cc_u32f ym2612_clock;
+	cc_u32f sn76489_clock;
+	cc_u32f frame_rate;
+	Uint64 frame_cycle_base; // Master-clock cycles elapsed before the current frame.
+	Uint64 start_sample;     // Sample of the first chip write; the leading silence is trimmed.
+	Uint64 total_samples;    // Samples emitted so far as wait commands.
+	std::vector<unsigned char> commands;
+	std::string software_name;
+
+	void WriteWait(Uint64 samples);
+
+public:
+	[[nodiscard]] bool IsRecording() const { return recording; }
+
+	void Start(bool pal_mode, std::string software_name);
+	void LogWrite(ClownMDEmu_SoundChip chip, cc_u8f address, cc_u8f data, cc_u32f cycle);
+	void AdvanceFrame();
+	[[nodiscard]] std::vector<unsigned char> Finish();
+};
+
+#endif // VGM_LOGGER_H


### PR DESCRIPTION
Adds a VGM recorder, driven by the core's new `sound_chip_written` callback (Clownacy/clownmdemu-core#106 — this PR depends on it and on the corresponding core/common submodule bumps, which are left to you).

- 'Start VGM Recording' / 'Stop VGM Recording...' menu items under Debugging. Saving reuses `FileUtilities::SaveFile`, so it also works in the web build.
- `VGMLogger` produces a VGM 1.51 file with a GD3 tag (the game name is read from the ROM header). Timing is measured in emulated master-clock cycles, so recordings made while fast-forwarding play back correctly. The YM2612 DAC (register 0x2A) is captured like any other register, so PCM sound effects are included.
- The recording is trimmed: the timeline is anchored on the first chip write, and the stream ends at the last command.
- Adds `UTF8ToUTF32` to text-encoding, for the GD3 tag's UTF-16 strings.
- The Qt frontend compiles the new files but does not expose the feature.

Known limitations: rewinding or loading a save state while recording will corrupt the log, and chip state prior to the recording is not captured (a recording started mid-tune only becomes accurate as registers are rewritten).
